### PR TITLE
Compilation fix + member customization based on access specifier

### DIFF
--- a/swang/README.rst
+++ b/swang/README.rst
@@ -89,6 +89,9 @@ defined.
 - ``class_constant``: a static constant (class)
 - ``class_member``: a static variable (class)
 - ``member_constant``: a constant member
+- ``member_private``: a private member
+- ``member_protected``: a protected member
+- ``member_public``: a public member
 - ``member``: a member
 - ``constant``: a constant
 - ``variable``: a variable
@@ -106,6 +109,9 @@ defined.
 
 - ``function``: a function
 - ``class_method``: a class (static) method
+- ``private_method``: a private method
+- ``protected_method``: a protected method
+- ``public_method``: a public method
 - ``method``: a method
 
 - ``typedef``: a ``typedef ... type``

--- a/swang/swang.cpp
+++ b/swang/swang.cpp
@@ -1459,8 +1459,8 @@ namespace swang {
   } // end anonymous namespace
 } // namespace swang
 
-auto build_path   = llvm::cl::opt< std::string >(llvm::cl::Positional, llvm::cl::desc("<build-path>"));
-auto source_paths = llvm::cl::list< std::string >(llvm::cl::Positional, llvm::cl::desc("<source0> [... <sourceN>]"), llvm::cl::OneOrMore);
+llvm::cl::opt<std::string> build_path(llvm::cl::Positional, llvm::cl::desc("<build-path>"));
+llvm::cl::list<std::string> source_paths(llvm::cl::Positional, llvm::cl::desc("<source0> [... <sourceN>]"), llvm::cl::OneOrMore);
 
 int main(int argc, const char** argv) {
   llvm::sys::PrintStackTraceOnErrorSignal();

--- a/swang/swang.cpp
+++ b/swang/swang.cpp
@@ -78,6 +78,9 @@ namespace swang {
     style enum_constant_style;
     style constexpr_variable_style;
     style member_constant_style;
+    style member_private_style;
+    style member_protected_style;
+    style member_public_style;
     style member_style;
     style class_constant_style;
     style class_member_style;
@@ -110,6 +113,9 @@ namespace swang {
     style constexpr_method_style;
     style virtual_method_style;
     style class_method_style;
+    style private_method_style;
+    style protected_method_style;
+    style public_method_style;
     style method_style;
 
     style typedef_style;
@@ -168,6 +174,9 @@ namespace llvm {
         io.mapOptional("enum_constant", style.enum_constant_style);
         io.mapOptional("constexpr", style.constexpr_variable_style);
         io.mapOptional("member_constant", style.member_constant_style);
+        io.mapOptional("member_private", style.member_private_style);
+        io.mapOptional("member_protected", style.member_protected_style);
+        io.mapOptional("member_public", style.member_public_style);
         io.mapOptional("member", style.member_style);
         io.mapOptional("class_constant", style.class_constant_style);
         io.mapOptional("class_member", style.class_member_style);
@@ -200,6 +209,9 @@ namespace llvm {
         io.mapOptional("constexpr_method", style.constexpr_method_style);
         io.mapOptional("virtual_method", style.virtual_method_style);
         io.mapOptional("class_method", style.class_method_style);
+        io.mapOptional("private_method", style.private_method_style);
+        io.mapOptional("protected_method", style.protected_method_style);
+        io.mapOptional("public_method", style.public_method_style);
         io.mapOptional("method", style.method_style);
 
         io.mapOptional("typedef", style.typedef_style);
@@ -715,6 +727,15 @@ namespace swang {
           } else if (!type.isNull() && type.isLocalConstQualified() && config.constant_style.is_set) {
             kindname = "constant member";
             style    = config.constant_style;
+          } else if (d->getAccess() == clang::AS_private && config.member_private_style.is_set) {
+            kindname = "private member";
+            style    = config.member_private_style;
+          } else if (d->getAccess() == clang::AS_protected && config.member_protected_style.is_set) {
+            kindname = "protected member";
+            style    = config.member_protected_style;
+          } else if (d->getAccess() == clang::AS_public && config.member_public_style.is_set) {
+            kindname = "public member";
+            style    = config.member_public_style;
           } else if (config.member_style.is_set) {
             kindname = "member";
             style    = config.member_style;
@@ -924,6 +945,15 @@ namespace swang {
           } else if (d->isVirtual() && config.virtual_method_style.is_set) {
             kindname = "virtual method";
             style    = config.virtual_method_style;
+          } else if (d->getAccess() == clang::AS_private && config.private_method_style.is_set) {
+            kindname = "private method";
+            style    = config.private_method_style;
+          } else if (d->getAccess() == clang::AS_protected && config.protected_method_style.is_set) {
+            kindname = "protected method";
+            style    = config.protected_method_style;
+          } else if (d->getAccess() == clang::AS_public && config.public_method_style.is_set) {
+            kindname = "public method";
+            style    = config.public_method_style;
           } else if (config.method_style.is_set) {
             kindname = "method";
             style    = config.method_style;


### PR DESCRIPTION
Hi,

First I fixed the following compilation issue that I got against trunk:

```cpp
/home/papin_g/projects/swang/llvm/tools/clang/tools/extra/swang/swang.cpp:1465:6: error: call to deleted constructor of 'llvm::cl::opt<std::string>'
auto build_path = llvm::cl::opt<std::string>(llvm::cl::Positional,
     ^            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/papin_g/projects/swang/llvm/include/llvm/Support/CommandLine.h:1232:3: note: 'opt' has been explicitly marked deleted here
  opt(const opt &) = delete;
  ^
```

Not sure if using `auto` in some other way could have made it to compile.


Second I added support in configuration based on access specifiers (public, protected, private).

The main use case I had was the following:

For private members of classes I have members prefixed with `m_`. But for simple structures, I do not want the public fields to be prefixed like this.

For example in my code I want to be able to do both of these things:

```cpp
class Foo
{
  public:
    int getAge() const { return m_age; }

  private:
    int m_age;
};

struct Point
{
  int x;
  int y;
}
```

It's possible now with the following `.swang`:

```yaml
member: { casing: camelBack, prefix: m_ }
member_public: { casing: camelBack }
```



